### PR TITLE
Fix max_tokens parameter

### DIFF
--- a/app/api/chat/azure/route.ts
+++ b/app/api/chat/azure/route.ts
@@ -51,11 +51,14 @@ export async function POST(request: Request) {
       defaultHeaders: { "api-key": KEY }
     })
 
+    const maxTokens =
+      chatSettings.model === "gpt-4-vision-preview" ? 4096 : undefined
+
     const response = await azureOpenai.chat.completions.create({
       model: DEPLOYMENT_ID as ChatCompletionCreateParamsBase["model"],
       messages: messages as ChatCompletionCreateParamsBase["messages"],
       temperature: chatSettings.temperature,
-      max_tokens: chatSettings.model === "gpt-4-vision-preview" ? 4096 : null, // TODO: Fix
+      max_tokens: maxTokens,
       stream: true
     })
 

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -24,15 +24,17 @@ export async function POST(request: Request) {
       organization: profile.openai_organization_id
     })
 
+    const maxTokens =
+      chatSettings.model === "gpt-4-vision-preview" ||
+      chatSettings.model === "gpt-4o"
+        ? 4096
+        : undefined
+
     const response = await openai.chat.completions.create({
       model: chatSettings.model as ChatCompletionCreateParamsBase["model"],
       messages: messages as ChatCompletionCreateParamsBase["messages"],
       temperature: chatSettings.temperature,
-      max_tokens:
-        chatSettings.model === "gpt-4-vision-preview" ||
-        chatSettings.model === "gpt-4o"
-          ? 4096
-          : null, // TODO: Fix
+      max_tokens: maxTokens,
       stream: true
     })
 


### PR DESCRIPTION
## Summary
- ensure `max_tokens` is omitted for non-vision models in OpenAI and Azure chat routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ca48fe9148324a2419941e2b7d220